### PR TITLE
Fix infrastructure namespaces and enhance CRUD base

### DIFF
--- a/Api/BaseBackEnd.Api/Controllers/CategoriaController.cs
+++ b/Api/BaseBackEnd.Api/Controllers/CategoriaController.cs
@@ -2,20 +2,14 @@
 using GestaoMonetariaApi.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 
-namespace GestaoMonetaria.Api.Controllers.Categoria
+namespace GestaoMonetariaApi.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CategoriaController : BaseController<CategoriaEntity>
 {
-    [ApiController]
-    [Route("api/[controller]")]
-    public class CategoriaController : BaseController<CategoriaEntity>
+    public CategoriaController(ICategoriaService categoriaService)
+        : base(categoriaService)
     {
-        private readonly ICategoriaService _operacaoService;
-
-        public CategoriaController(ICategoriaService operacaoService)
-            : base(operacaoService)
-        {
-            _operacaoService = operacaoService;
-        }
-
-
     }
 }

--- a/Api/BaseBackEnd.Api/Extensions/DependencyInjection.cs
+++ b/Api/BaseBackEnd.Api/Extensions/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using AutoMapper;
+using BaseBackEnd.Domain;
 using GestaoMonetariaApi.Application.Interfaces.Services;
 using GestaoMonetariaApi.Application.Services;
 using GestaoMonetariaApi.Domain.Interfaces.Repositories;
@@ -15,11 +16,11 @@ namespace GestaoMonetariaApi.Api.Extensions
 
             services.AddScoped<IOperacaoService, OperacaoService>();
             services.AddScoped<IOperacaoRepository, OperacaoRepository>();
-            
+
             services.AddScoped<ICategoriaService, CategoriaService>();
             services.AddScoped<ICategoriaRepository, CategoriaRepository>();
 
-
+            services.AddAutoMapper(typeof(MappingProfile));
 
             return services;
         }

--- a/Api/BaseBackEnd.Api/Program.cs
+++ b/Api/BaseBackEnd.Api/Program.cs
@@ -1,18 +1,15 @@
 using GestaoMonetariaApi.Api.Extensions;
-using GestaoMonetariaApi.Infrastructure.Configurations.Fundation;
+using GestaoMonetariaApi.Infrastructure.Configurations.Foundation;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Configuração da aplicação
+// ConfiguraÃ§Ã£o da aplicaÃ§Ã£o
 builder.Configuration
     .SetBasePath(Directory.GetCurrentDirectory())
     .AddJsonFile("./Properties/appsettings.json", optional: false, reloadOnChange: true);
 
-// Connection string (opcional se usada internamente)
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-
-// Injeta serviços da infraestrutura
+// Injeta serviÃ§os da infraestrutura
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddDependencies();
 

--- a/Application/BaseBackEnd.Application/Interfaces/Services/IBaseService.cs
+++ b/Application/BaseBackEnd.Application/Interfaces/Services/IBaseService.cs
@@ -2,7 +2,7 @@
 {
     public interface IBaseService<T> where T : class
     {
-        Task<T> GetByIdAsync(int id);
+        Task<T?> GetByIdAsync(int id);
         Task<IEnumerable<T>> GetAllAsync();
         Task AddAsync(T entity);
         Task UpdateAsync(T entity);

--- a/Application/BaseBackEnd.Application/Services/BaseService.cs
+++ b/Application/BaseBackEnd.Application/Services/BaseService.cs
@@ -1,4 +1,5 @@
 ﻿using GestaoMonetariaApi.Application.Interfaces.Services;
+using GestaoMonetariaApi.Domain.Interfaces.Repositories;
 
 namespace GestaoMonetariaApi.Application.Services
 {
@@ -11,7 +12,7 @@ namespace GestaoMonetariaApi.Application.Services
             _repository = repository;
         }
 
-        public async Task<T> GetByIdAsync(int id)
+        public async Task<T?> GetByIdAsync(int id)
         {
             return await _repository.GetByIdAsync(id);
         }

--- a/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/ApplicationDbContext.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/ApplicationDbContext.cs
@@ -1,9 +1,8 @@
 ﻿using GestaoMonetariaApi.Domain.Entities;
-using GestaoMonetariaApi.Infrastructure.Configurations.Foundation;
+using GestaoMonetariaApi.Infrastructure.Configurations;
 using Microsoft.EntityFrameworkCore;
-using SeuNamespace;
 
-namespace GestaoMonetariaApi.Infrastructure.Configurations.Fundation
+namespace GestaoMonetariaApi.Infrastructure.Configurations.Foundation
 {
     public class ApplicationDbContext : DbContext
     {
@@ -15,8 +14,8 @@ namespace GestaoMonetariaApi.Infrastructure.Configurations.Fundation
         // -----------------------
         //  DbSets (Entidades)
         // -----------------------
-        public DbSet<OperacaoEntity> Operacoes { get; set; }
-        public DbSet<CategoriaEntity> Categorias { get; set; }
+        public DbSet<OperacaoEntity> Operacoes { get; set; } = null!;
+        public DbSet<CategoriaEntity> Categorias { get; set; } = null!;
 
         // -----------------------
         //  Configurações

--- a/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/ApplicationDbContextFactory.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/ApplicationDbContextFactory.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 
-namespace GestaoMonetariaApi.Infrastructure.Configurations.Fundation
+namespace GestaoMonetariaApi.Infrastructure.Configurations.Foundation
 {
     public class ApplicationDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
     {

--- a/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/DependencyInjection.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Configurations/Foundation/DependencyInjection.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace GestaoMonetariaApi.Infrastructure.Configurations.Fundation
+namespace GestaoMonetariaApi.Infrastructure.Configurations.Foundation
 {
     public static class DependencyInjection
     {

--- a/Infrastructure/BaseBackEnd.Infrastructure/Configurations/OperacaoConfiguration.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Configurations/OperacaoConfiguration.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace SeuNamespace
+namespace GestaoMonetariaApi.Infrastructure.Configurations
 {
     public class OperacaoConfiguration : IEntityTypeConfiguration<OperacaoEntity>
     {

--- a/Infrastructure/BaseBackEnd.Infrastructure/Interfaces/Repositories/IBaseRepository.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Interfaces/Repositories/IBaseRepository.cs
@@ -1,6 +1,8 @@
-﻿public interface IBaseRepository<T> where T : class
+namespace GestaoMonetariaApi.Domain.Interfaces.Repositories;
+
+public interface IBaseRepository<T> where T : class
 {
-    Task<T> GetByIdAsync(int id);
+    Task<T?> GetByIdAsync(int id);
     Task<IEnumerable<T>> GetAllAsync();
     Task AddAsync(T entity);
     void Update(T entity);

--- a/Infrastructure/BaseBackEnd.Infrastructure/Repositories/BaseRepository.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Repositories/BaseRepository.cs
@@ -1,5 +1,8 @@
-﻿using GestaoMonetariaApi.Infrastructure.Configurations.Fundation;
+using GestaoMonetariaApi.Domain.Interfaces.Repositories;
+using GestaoMonetariaApi.Infrastructure.Configurations.Foundation;
 using Microsoft.EntityFrameworkCore;
+
+namespace GestaoMonetariaApi.Infrastructure.Repositories;
 
 public class BaseRepository<T> : IBaseRepository<T> where T : class
 {
@@ -12,7 +15,7 @@ public class BaseRepository<T> : IBaseRepository<T> where T : class
         _dbSet = context.Set<T>();
     }
 
-    public async Task<T> GetByIdAsync(int id)
+    public async Task<T?> GetByIdAsync(int id)
     {
         return await _dbSet.FindAsync(id);
     }

--- a/Infrastructure/BaseBackEnd.Infrastructure/Repositories/CategoriaRepository.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Repositories/CategoriaRepository.cs
@@ -1,14 +1,12 @@
 ﻿using GestaoMonetariaApi.Domain.Entities;
 using GestaoMonetariaApi.Domain.Interfaces.Repositories;
-using GestaoMonetariaApi.Infrastructure.Configurations.Fundation;
+using GestaoMonetariaApi.Infrastructure.Configurations.Foundation;
 
-namespace GestaoMonetariaApi.Infrastructure.Repositories
+namespace GestaoMonetariaApi.Infrastructure.Repositories;
+
+public class CategoriaRepository : BaseRepository<CategoriaEntity>, ICategoriaRepository
 {
-    public class CategoriaRepository : BaseRepository<CategoriaEntity>, ICategoriaRepository
+    public CategoriaRepository(ApplicationDbContext context) : base(context)
     {
-        public CategoriaRepository(ApplicationDbContext context) : base(context)
-        {
-        }
-
     }
 }

--- a/Infrastructure/BaseBackEnd.Infrastructure/Repositories/OperacaoRepository.cs
+++ b/Infrastructure/BaseBackEnd.Infrastructure/Repositories/OperacaoRepository.cs
@@ -1,14 +1,12 @@
 ﻿using GestaoMonetariaApi.Domain.Entities;
 using GestaoMonetariaApi.Domain.Interfaces.Repositories;
-using GestaoMonetariaApi.Infrastructure.Configurations.Fundation;
+using GestaoMonetariaApi.Infrastructure.Configurations.Foundation;
 
-namespace GestaoMonetariaApi.Infrastructure.Repositories
+namespace GestaoMonetariaApi.Infrastructure.Repositories;
+
+public class OperacaoRepository : BaseRepository<OperacaoEntity>, IOperacaoRepository
 {
-    public class OperacaoRepository : BaseRepository<OperacaoEntity>, IOperacaoRepository
+    public OperacaoRepository(ApplicationDbContext context) : base(context)
     {
-        public OperacaoRepository(ApplicationDbContext context) : base(context)
-        {
-        }
-
     }
 }


### PR DESCRIPTION
## Summary
- standardize the infrastructure namespaces, remove placeholder references, and ensure the EF Core context/configuration wiring is correct
- update repository/service contracts to return nullable results, improve the generic CRUD controller flow, and register AutoMapper for view model mapping
- clean up the API bootstrap so infrastructure dependencies are registered consistently

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6c3d595508329b83e9277ae61a8f6